### PR TITLE
Resolve "Optimize ClassCode"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,8 +127,6 @@ version = "0.4.0"
 dependencies = [
  "lazy_static",
  "regex",
- "serde",
- "serde_json",
 ]
 
 [[package]]

--- a/tracker/lib/Cargo.toml
+++ b/tracker/lib/Cargo.toml
@@ -6,5 +6,3 @@ edition = "2021"
 [dependencies]
 regex = "1.5.5"
 lazy_static = "1.4.0"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"

--- a/tracker/lib/src/class_code.rs
+++ b/tracker/lib/src/class_code.rs
@@ -1,5 +1,4 @@
 use regex::Regex;
-use serde::{Deserialize, Serialize};
 use std::{fmt, rc::Rc};
 
 lazy_static! {
@@ -7,7 +6,7 @@ lazy_static! {
 }
 
 /// String wrapper to enforce the Class Code invariant.
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, Clone, Hash)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Hash)]
 pub struct ClassCode(String);
 
 impl ClassCode {

--- a/tracker/lib/src/class_code.rs
+++ b/tracker/lib/src/class_code.rs
@@ -38,15 +38,15 @@ impl ClassCodes {
         Self(Vec::new())
     }
 
-    pub fn get(&mut self, s: &str) -> Rc<ClassCode> {
+    pub fn get(&mut self, s: &str) -> Result<Rc<ClassCode>, &'static str> {
         if let Some(c) = self.0.iter().find(|r| r.0 == s) {
-            return Rc::clone(c);
+            return Ok(Rc::clone(c));
         }
 
-        let cc = ClassCode::new(s).unwrap();
+        let cc = ClassCode::new(s)?;
         let rc = Rc::new(cc);
         self.0.push(rc);
-        return Rc::clone(self.0.last().unwrap());
+        Ok(Rc::clone(self.0.last().unwrap()))
     }
 }
 
@@ -101,9 +101,10 @@ mod tests {
         let mut codes = ClassCodes::new();
 
         // get multiple times but the actual number of ClassCode instances is 1
-        codes.get("TEST111");
-        codes.get("TEST111");
-
+        let a = codes.get("TEST111");
+        let b = codes.get("TEST111");
+        assert!(a.is_ok());
+        assert!(b.is_ok());
         assert_eq!(1, codes.0.len());
     }
 
@@ -112,11 +113,11 @@ mod tests {
         let mut codes = ClassCodes::new();
 
         // 5 different class codes creates 5 instances
-        codes.get("TEST001");
-        codes.get("TEST002");
-        codes.get("TEST003");
-        codes.get("TEST004");
-        codes.get("TEST005");
+        let _ = codes.get("TEST001");
+        let _ = codes.get("TEST002");
+        let _ = codes.get("TEST003");
+        let _ = codes.get("TEST004");
+        let _ = codes.get("TEST005");
 
         assert_eq!(5, codes.0.len());
     }

--- a/tracker/lib/src/class_code.rs
+++ b/tracker/lib/src/class_code.rs
@@ -120,4 +120,16 @@ mod tests {
 
         assert_eq!(5, codes.0.len());
     }
+
+    #[test]
+    fn class_codes_3() {
+        let mut codes = ClassCodes::new();
+        let a = codes.get("");
+        let b = codes.get("blah blah blah");
+        let c = codes.get("blah122");
+        assert!(a.is_err());
+        assert!(b.is_err());
+        assert!(c.is_err());
+        assert_eq!(0, codes.0.len());
+    }
 }

--- a/tracker/lib/src/lib.rs
+++ b/tracker/lib/src/lib.rs
@@ -5,7 +5,7 @@ mod assignment;
 pub use assignment::Assignment;
 
 mod class_code;
-pub use class_code::ClassCode;
+pub use class_code::{ClassCode, ClassCodes};
 
 mod tracker;
 pub use tracker::Tracker;

--- a/tracker/lib/src/lib.rs
+++ b/tracker/lib/src/lib.rs
@@ -5,7 +5,7 @@ mod assignment;
 pub use assignment::Assignment;
 
 mod class_code;
-pub use class_code::{ClassCode, ClassCodes};
+pub use class_code::ClassCode;
 
 mod tracker;
 pub use tracker::Tracker;

--- a/tracker/lib/src/tracker.rs
+++ b/tracker/lib/src/tracker.rs
@@ -1,4 +1,4 @@
-use crate::{Assignment, ClassCode};
+use crate::{Assignment, ClassCode, ClassCodes};
 
 /// Track assignments.
 #[derive(Debug, PartialEq, PartialOrd)]
@@ -7,6 +7,8 @@ pub struct Tracker {
 }
 
 type ValidResult = Result<(), &'static str>;
+
+const CODES: ClassCodes = ClassCodes(vec![]);
 
 impl Tracker {
     /// Create a new default tracker.


### PR DESCRIPTION
# Changes

- Track the references to all ```ClassCode``` instances in ```Tracker```
- Migrate from using ```ClassCode``` to use ```Rc<ClassCode>```
- Add function to get ```ClassCode``` from given ```String```
- Remove ```serde``` dependency since serialization should be done in CLI not library

# New Syntax

The new syntax to get the codes is:
```
let tracker = Tracker::new();
let _ = Assignment::new("Assignment 1", 25.0, tracker.get_code("SOME101").unwrap()).unwrap();
```

The syntax requires access to an instance of ```Tracker``` since the class codes are cached within ```Tracker```. This was done to prevent the use of mutable static fields which require using ```unsafe```.

# Issues

Closes #4 