### PR TITLE
Resolve "Modular command system"

### DIFF
--- a/tracker/cli/src/main.rs
+++ b/tracker/cli/src/main.rs
@@ -1,3 +1,6 @@
+#[macro_use]
+extern crate prettytable;
+
 use prettytable::{Cell, Row, Table};
 use rand::prelude::*;
 use std::{
@@ -17,6 +20,8 @@ fn main() {
     let args: Vec<String> = env::args().skip(1).collect();
     let filename = args.get(0).expect("A filename (or path) must be provided");
     let mut tracker = read_file(&filename).expect("Problem finding the given filename");
+
+    println!("Enter command or help to get a list of commands");
 
     loop {
         let input: Vec<String> = get_input()
@@ -42,10 +47,19 @@ fn main() {
     }
 }
 
+/// Execute a command based on `cmd` using the `args` and [`tracker`](Tracker).
 fn do_command(cmd: &str, args: &Vec<String>, tracker: &mut Tracker) -> Result<()> {
     match cmd {
+        _ if cmd == "help" => {
+            ptable!(
+                ["COMMAND", "ARGUMENTS", "DESCRIPTION"],
+                ["help", "", "print this message"],
+                ["write", "<filename>", "write the tracker to the given file"],
+                ["print", "", "print a table of all assignments"]
+            );
+        }
         _ if cmd == "write" => {
-            if let Some(filename) = args.get(1) {
+            if let Some(filename) = args.get(0) {
                 println!("Writing to {}...", filename);
                 write_file(&tracker, filename).unwrap();
             }
@@ -59,6 +73,10 @@ fn do_command(cmd: &str, args: &Vec<String>, tracker: &mut Tracker) -> Result<()
     Ok(())
 }
 
+/// Get user input.
+///
+/// Print "`> `" to the console to indicate the user can enter commands.
+/// Then retrieve the user input and trim the line.
 fn get_input() -> Result<String> {
     print!("> ");
     io::stdout().flush()?;


### PR DESCRIPTION
# Changes

- Add `do_command()` to manage and check commands from user input.
- Add commands for `help`, `write` and `print`

# Syntax

A command can be added by adding to the `match` in `do_command()` with the following:
```
_ if cmd == "<cmd name>" => {
    do_something(args, &tracker);
}
```

This is not the proposed syntax since it was not possible to use it with mutable references. However, a solution could be made for it but it would require further research. 

# Issues

Closes #10 
